### PR TITLE
[MRG] Refactor: remove ReadyCorpus

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,10 +10,10 @@ works::
    # Create a corpus from data that has already been preprocessed.
    # Among other things, this will divide the corpus into training,
    # validation and test sets.
-   from persephone.corpus import Corpus, ReadyCorpus
-   corpus = ReadyCorpus(tgt_dir="/path/to/preprocessed/data",
-                        feat_type="fbank",
-                        label_type="phonemes")
+   from persephone.corpus import Corpus
+   corpus = Corpus(feat_type="fbank",
+                    label_type="phonemes",
+                    tgt_dir="/path/to/preprocessed/data")
 
    # Create an object that reads the corpus data in batches.
    from persephone.corpus_reader import CorpusReader
@@ -63,9 +63,6 @@ classes. `Utterance` instances comprise `Corpus` instances, which are loaded by
 ..                             utterance_filter=function_to_call,
 ..                             label_segmenter=something,
 ..                             tier_prefixes=("xv", "rf"))
-
-.. autoclass:: persephone.corpus.ReadyCorpus
-   :members: __init__, determine_labels
 
 .. autoclass:: persephone.corpus_reader.CorpusReader
    :members: __init__, 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -100,7 +100,7 @@ interpreter. Back to the terminal:
 
     $ ipython
     > from persephone import corpus
-    > corp = corpus.ReadyCorpus("data/na_example")
+    > corp = corpus.Corpus("fbank", "phonemes", "data/na_example")
     > from persephone import run
     > run.train_ready(corp)
 
@@ -149,7 +149,7 @@ format your data in the same way, you can create your own Persephone
 
 .. code:: python
 
-    corp = corpus.ReadyCorpus("<your-corpus-directory>", label_type="extension")
+    corp = corpus.Corpus("fbank", "phonemes", "<your-corpus-directory>")
 
 where extension is "txt", "phonemes", "tones", or whatever your file has
 after the dot.
@@ -197,7 +197,7 @@ Current data formatting requirements:
 * Spaces are used to delimit the units that the tool predicts. Typically these units are phonemes or tones, however they could also just be orthographic characters (though performance is likely to be a bit lower: consider trying to transcribe "$100"). The model can't tell the difference between digraphs and unigraphs as long as they're tokenized in this format, demarcated with spaces.
 
 If your data observes this format then you can load it via the
-``ReadyCorpus`` class. If your data does not observe this format, you
+``Corpus`` class. If your data does not observe this format, you
 have two options:
 
 1. Do your own separate preprocessing to get the data in this format. If
@@ -205,27 +205,26 @@ have two options:
    you have ELAN files, this probably means using
    ``persephone/scripts/split_eaf.py``.
 2. Create a Python class that inherits from ``persephone.corpus.Corpus``
-   (as does ``ReadyCorpus``) and does all your preprocessing. The API
+   and does all your preprocessing. The API
    (and thus documentation) for this is work in progress, but the key
    point is that ``<corpusobject>.train_prefixes``,
    ``<corpusobject>.valid_prefixes``, and
    ``<corpusobject>.test_prefixes`` are lists of prefixes for the
-   relevant subset of the data. For now, look at ``ReadyCorpus`` in
-   ``persephone/corpus.py`` for an example. For an example on a full
+   relevant subset of the data. For an example on a full
    dataset, see at ``persephone/datasets/na.py`` (beware: here be
    dragons).
 
 Creating validation and test sets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Currently ``ReadyCorpus`` splits the supplied data into three sets
+Currently ``Corpus`` splits the supplied data into three sets
 (training, validation and test) in a 95:5:5 ratio. The training set is
 what your model is exposed to during training. Validation is a held-out
 set that is used to gauge during training how well the model is
 performing. Testing is what is used to quantitatively assess model
 performance after training is complete.
 
-When you first load your corpus, ``ReadyCorpus`` randomly allocates
+When you first load your corpus, ``Corpus`` randomly allocates
 files to each of these subsets. If you'd like to do change the prefixes
 of which utterances are in in each set, modify
 ``<your-corpus>/valid_prefixes.txt`` and
@@ -283,7 +282,7 @@ like to hear people's thoughts on this interface.
 CorpusReaders and Models
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``Corpus`` object (of which ``ReadyCorpus`` is a subclass), is an
+The ``Corpus`` object, is an
 object that exposes the files in the corpus (among several other
 things). Of relevance here is the ``.get_train_fns()``,
 ``.get_valid_fns()``, ``.get_test_fns()`` methods, which provide lists
@@ -304,7 +303,7 @@ example na\_corpus):
 .. code:: python
 
     from persephone import corpus
-    na_corpus = corpus.ReadyCorpus("data/na_example/")
+    na_corpus = corpus.Corpus("fbank", "phonemes", "data/na_example/")
     from persephone import corpus_reader
     na_reader = corpus_reader.CorpusReader(na_corpus, num_train=512, batch_size=16)
 

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -100,7 +100,7 @@ class Corpus:
         # Label-related stuff
         self.labels = labels
         self.vocab_size = len(self.labels)
-        self.initialize_labels(self.labels)
+        self.LABEL_TO_INDEX, self.INDEX_TO_LABEL = self.initialize_labels(self.labels)
         logger.info("Corpus label set: \n\t{}".format(self.labels))
 
         # This is a lazy function that assumes wavs are already in the WAV dir
@@ -257,10 +257,12 @@ class Corpus:
         """Create mappings from label to index and index to label"""
         logger.debug("Creating mappings for labels")
 
-        self.LABEL_TO_INDEX = {label: index for index, label in enumerate(
-                                 ["pad"] + sorted(list(self.labels)))}
-        self.INDEX_TO_LABEL = {index: phn for index, phn in enumerate(
-                                 ["pad"] + sorted(list(self.labels)))}
+        label_to_index = {label: index for index, label in enumerate(
+                                 ["pad"] + sorted(list(labels)))}
+        index_to_label = {index: phn for index, phn in enumerate(
+                                 ["pad"] + sorted(list(labels)))}
+
+        return label_to_index, index_to_label
 
     def prepare_feats(self):
         """ Prepares input features"""

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -487,7 +487,7 @@ class Corpus:
                     "Feature matrix of shape %s unexpected" % str(feats.shape))
         return self._num_feats
 
-    def prefixes_to_fns(self, prefixes):
+    def prefixes_to_fns(self, prefixes: List[str]) -> Tuple[List[str], List[str]]:
         # TODO Return pathlib.Paths
         feat_fns = [str(self.feat_dir / ("%s.%s.npy" % (prefix, self.feat_type)))
                     for prefix in prefixes]
@@ -549,7 +549,7 @@ class Corpus:
 
         return prefixes
 
-    def review(self):
+    def review(self) -> None:
         """ Used to play the WAV files and compare with the transcription. """
 
         for prefix in self.determine_prefixes():
@@ -561,7 +561,7 @@ class Corpus:
             print("Transcription: {}".format(transcript))
             subprocess.run(["play", str(wav_fn)])
 
-    def pickle(self):
+    def pickle(self) -> None:
         """ Pickles the Corpus object in a file in tgt_dir. """
 
         pickle_path = self.tgt_dir / "corpus.p"

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -45,7 +45,16 @@ def ensure_no_set_overlap(train, valid, test) -> None:
         logger.warning("valid and test have overlapping items: {}".format(valid & test))
         raise PersephoneException("valid and test have overlapping items: {}".format(valid & test))
 
-
+def find_untranscribed_wavs(wav_path: Path, transcription_path: Path, label_type: str) -> List[str]:
+    """Find the prefixes for all the wav files that do not have an associated transcription
+    Args:
+        wav_path: Path to search for wav files in
+        transcription_path: Path to search for transcriptions in
+        label_type: The type of labels for transcriptions. Eg "phonemes" "ponemes_and_tones"
+    Returns:
+        A list of all untranscribed prefixes
+    """
+    raise NotImplementedError
 
 class Corpus:
     """ Represents a preprocessed corpus that is ready to be used in model

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -435,7 +435,7 @@ class Corpus:
         return self.prefixes_to_fns(self.test_prefixes)
 
     def get_untranscribed_prefixes(self) -> List[str]:
-
+        """Find which prefixes do not have an associated transcription file"""
         # TODO Change to pathlib.Path
         untranscribed_prefix_fn = join(str(self.tgt_dir), "untranscribed_prefixes.txt")
         if os.path.exists(untranscribed_prefix_fn):

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -159,6 +159,12 @@ class Corpus:
         self.label_type = label_type
 
         # Setting up directories
+        # Set the directory names
+        self.tgt_dir = tgt_dir
+        self.feat_dir = self.get_feat_dir()
+        self.wav_dir = self.get_wav_dir()
+        self.label_dir = self.get_label_dir()
+        
         logger.debug("Setting up directories for this Corpus object at %s", tgt_dir)
         self.set_and_check_directories(tgt_dir)
 
@@ -179,8 +185,6 @@ class Corpus:
         self.test_prefixes = [] # type: List[str]
         # This is also lazy if the {train,valid,test}_prefixes.txt files exist.
         self.make_data_splits(max_samples=max_samples)
-
-
 
         # Sort the training prefixes by size for more efficient training
         logger.debug("Training prefixes")
@@ -314,13 +318,7 @@ class Corpus:
         Make sure that the required directories exist in the target directory.
         set variables accordingly.
         """
-
         logger.info("Setting up directories for corpus in %s", tgt_dir)
-        # Set the directory names
-        self.tgt_dir = tgt_dir
-        self.feat_dir = self.get_feat_dir()
-        self.wav_dir = self.get_wav_dir()
-        self.label_dir = self.get_label_dir()
 
         # Check directories exist.
         if not tgt_dir.is_dir():
@@ -371,7 +369,7 @@ class Corpus:
         if should_extract_feats:
             feat_extract.from_dir(self.feat_dir, self.feat_type)
 
-    def make_data_splits(self, max_samples) -> None:
+    def make_data_splits(self, max_samples: int) -> None:
         """ Splits the utterances into training, validation and test sets."""
 
         train_f_exists = self.train_prefix_fn.is_file()

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -65,6 +65,34 @@ def find_untranscribed_wavs(wav_path: Path, transcription_path: Path, label_type
             untranscribed_prefixes.append(a_file.stem)
     return untranscribed_prefixes
 
+def get_untranscribed_prefixes_from_file(target_directory: Path) -> List[str]:
+    """
+    The file "untranscribed_prefixes.txt" will specify prefixes which
+    do not have an associated transcription file if placed in the target directory.
+
+    This will fetch those prefixes from that file and will return an empty
+    list if that file does not exist.
+
+    See find_untranscribed_wavs function for finding untranscribed prefixes in an
+    experiment directory.
+
+    Returns:
+        A list of all untranscribed prefixes as specified in the file
+    """
+    # TODO Change to pathlib.Path
+    untranscribed_prefix_fn = join(str(target_directory), "untranscribed_prefixes.txt")
+    if os.path.exists(untranscribed_prefix_fn):
+        with open(untranscribed_prefix_fn) as f:
+            prefixes = f.readlines()
+
+        return [prefix.strip() for prefix in prefixes]
+    else:
+        logger.warning("Attempting to get untranscribed prefixes but the file ({})"
+                        " that should specify these does not exist".format(untranscribed_prefix_fn))
+    return []
+
+
+
 class Corpus:
     """ Represents a preprocessed corpus that is ready to be used in model
     training.

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -138,11 +138,15 @@ class Corpus:
             self.feat_dir, self.train_prefixes, feat_type)
 
         # Ensure no overlap between training and test sets
-        ensure_no_set_overlap(
-            self.get_train_fns()[0],
-            self.get_valid_fns()[0],
-            self.get_test_fns()[0]
-        )
+        try:
+            ensure_no_set_overlap(
+                self.get_train_fns()[0],
+                self.get_valid_fns()[0],
+                self.get_test_fns()[0]
+            )
+        except PersephoneException:
+            logger.error("Got overlap between train valid and test data sets")
+            raise
 
         self.untranscribed_prefixes = self.get_untranscribed_prefixes()
 

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -54,12 +54,11 @@ def find_untranscribed_wavs(wav_path: Path, transcription_path: Path, label_type
     Returns:
         A list of all untranscribed prefixes
     """
-    audio_files = sorted(wav_path.glob("**/*.wav"))
-    transcription_files = sorted(transcription_path.glob("**/*.{}".format(label_type)))
+    audio_files = wav_path.glob("**/*.wav")
+    transcription_files = transcription_path.glob("**/*.{}".format(label_type))
     
     transcription_file_prefixes = [t_file.stem for t_file in transcription_files]
 
-    import pdb; pdb.set_trace()
     untranscribed_prefixes = [] # type: List[str]
     for a_file in audio_files:
         if a_file.stem not in transcription_file_prefixes:

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -193,7 +193,10 @@ class Corpus:
             logger.error("Got overlap between train valid and test data sets")
             raise
 
-        self.untranscribed_prefixes = self.get_untranscribed_prefixes()
+        untranscribed_from_file = self.get_untranscribed_prefixes()
+        untranscribed_found = find_untranscribed_wavs(self.get_wav_dir(), self.get_label_dir(), self.label_type)
+
+        self.untranscribed_prefixes = list(set(untranscribed_from_file) & set(untranscribed_found))
 
         # TODO Need to contemplate whether Corpus objects have Utterance
         # objects or # not. Some of the TestBKW tests currently rely on this

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -589,16 +589,15 @@ def determine_labels(target_dir: Path, label_type: str) -> set:
     """
     logger.info("Finding phonemes of type %s in directory %s", label_type, target_dir)
 
-    tgt_dir = str(target_dir)
-    label_dir = str(target_dir / "label/")
-    if not os.path.isdir(label_dir):
+    label_dir = target_dir / "label/"
+    if not label_dir.is_dir():
         raise FileNotFoundError(
-            "The directory {} does not exist.".format(tgt_dir))
+            "The directory {} does not exist.".format(target_dir))
 
     phonemes = set() # type: set
-    for fn in os.listdir(label_dir):
-        if fn.endswith(label_type):
-            with open(os.path.join(label_dir, fn)) as f:
+    for fn in os.listdir(str(label_dir)):
+        if fn.endswith(str(label_type)):
+            with (label_dir / fn).open("r") as f:
                 try:
                     line_phonemes = set(f.readline().split())
                 except UnicodeDecodeError:

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -79,10 +79,10 @@ def get_untranscribed_prefixes_from_file(target_directory: Path) -> List[str]:
     Returns:
         A list of all untranscribed prefixes as specified in the file
     """
-    # TODO Change to pathlib.Path
-    untranscribed_prefix_fn = join(str(target_directory), "untranscribed_prefixes.txt")
-    if os.path.exists(untranscribed_prefix_fn):
-        with open(untranscribed_prefix_fn) as f:
+
+    untranscribed_prefix_fn = target_directory / "untranscribed_prefixes.txt"
+    if untranscribed_prefix_fn.exists():
+        with untranscribed_prefix_fn.open() as f:
             prefixes = f.readlines()
 
         return [prefix.strip() for prefix in prefixes]

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -606,20 +606,3 @@ def determine_labels(target_dir: Path, label_type: str) -> set:
                     raise
                 phonemes = phonemes.union(line_phonemes)
     return phonemes
-
-
-class ReadyCorpus(Corpus):
-    """ Interface to a corpus that has WAV files and label files split into
-    utterances and segregated in a directory with a "wav" and "label" dir. """
-
-    def __init__(self, tgt_dir, feat_type="fbank", label_type="phonemes"):
-        import warnings
-        warnings.warn(
-            "ReadyCorpus is deprecated, use Corpus instead",
-            DeprecationWarning
-        )
-        labels = determine_labels(tgt_dir, label_type)
-
-        super().__init__(feat_type, label_type, Path(tgt_dir), labels)
-
-

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -92,7 +92,6 @@ def get_untranscribed_prefixes_from_file(target_directory: Path) -> List[str]:
     return []
 
 
-
 class Corpus:
     """ Represents a preprocessed corpus that is ready to be used in model
     training.
@@ -519,17 +518,7 @@ class Corpus:
         See find_untranscribed_wavs function for finding untranscribed prefixes in an
         experiment directory.
         """
-        # TODO Change to pathlib.Path
-        untranscribed_prefix_fn = join(str(self.tgt_dir), "untranscribed_prefixes.txt")
-        if os.path.exists(untranscribed_prefix_fn):
-            with open(untranscribed_prefix_fn) as f:
-                prefixes = f.readlines()
-
-            return [prefix.strip() for prefix in prefixes]
-        else:
-            logger.warning("Attempting to get untranscribed prefixes but the file ({})"
-                           " that should specify these does not exist".format(untranscribed_prefix_fn))
-        return []
+        return get_untranscribed_prefixes_from_file(self.tgt_dir)
 
     def get_untranscribed_fns(self) -> List[str]:
         feat_fns = [os.path.join(str(self.feat_dir), "untranscribed", "%s.%s.npy" % (prefix, self.feat_type))

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -98,8 +98,10 @@ class Corpus:
         self.set_and_check_directories(tgt_dir)
 
         # Label-related stuff
-        self.initialize_labels(labels)
-        logger.info("Corpus label set: \n\t{}".format(labels))
+        self.labels = labels
+        self.vocab_size = len(self.labels)
+        self.initialize_labels(self.labels)
+        logger.info("Corpus label set: \n\t{}".format(self.labels))
 
         # This is a lazy function that assumes wavs are already in the WAV dir
         # but only creates features if necessary
@@ -156,7 +158,7 @@ class Corpus:
                 is it needs to carry with it a list of labels. This could
                 potentially be a function attribute.
             speakers: A list of speakers to filter for. If `None`, utterances
-                from speakers are.
+                from all speakers are included.
             tier_prefixes: A collection of strings that prefix ELAN tiers to
                 filter for. For example, if this is `("xv", "rf")`, then tiers
                 named "xv", "xv@Mark", "rf@Rose" would be extracted if they
@@ -252,10 +254,9 @@ class Corpus:
                 "The supplied path requires a 'label' subdirectory.")
 
     def initialize_labels(self, labels):
-
+        """Create mappings from label to index and index to label"""
         logger.debug("Creating mappings for labels")
-        self.labels = labels
-        self.vocab_size = len(self.labels)
+
         self.LABEL_TO_INDEX = {label: index for index, label in enumerate(
                                  ["pad"] + sorted(list(self.labels)))}
         self.INDEX_TO_LABEL = {index: phn for index, phn in enumerate(

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -481,7 +481,16 @@ class Corpus:
         return self.prefixes_to_fns(self.test_prefixes)
 
     def get_untranscribed_prefixes(self) -> List[str]:
-        """Find which prefixes do not have an associated transcription file"""
+        """
+        The file "untranscribed_prefixes.txt" will specify prefixes which
+        do not have an associated transcription file if placed in the target directory.
+
+        This will fetch those prefixes from that file and will return an empty
+        list if that file does not exist.
+
+        See find_untranscribed_wavs function for finding untranscribed prefixes in an
+        experiment directory.
+        """
         # TODO Change to pathlib.Path
         untranscribed_prefix_fn = join(str(self.tgt_dir), "untranscribed_prefixes.txt")
         if os.path.exists(untranscribed_prefix_fn):

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -8,7 +8,6 @@ import logging.config
 import os
 from pathlib import Path
 import pickle
-from os.path import join
 import random
 import subprocess
 from typing import Any, List, Callable, Optional, Set, Sequence, Tuple, Type, TypeVar
@@ -579,11 +578,19 @@ class Corpus:
 
 
 def determine_labels(target_dir: Path, label_type: str) -> set:
-    """ Returns a set of phonemes found in the corpus. """
+    """ Returns a set of all phonemes found in the corpus. Assumes that WAV files and
+    label files are split into utterances and segregated in a directory which contains a
+    "wav" subdirectory and "label" subdirectory.
+
+    Arguments:
+        target_dir: A `Path` to the directory where the corpus data is found
+        label_type: The type of label we are creating the label set from. For example
+                    "phonemes" would only search for labels for that type.
+    """
     logger.info("Finding phonemes of type %s in directory %s", label_type, target_dir)
 
     tgt_dir = str(target_dir)
-    label_dir = os.path.join(tgt_dir, "label/")
+    label_dir = str(target_dir / "label/")
     if not os.path.isdir(label_dir):
         raise FileNotFoundError(
             "The directory {} does not exist.".format(tgt_dir))
@@ -591,7 +598,7 @@ def determine_labels(target_dir: Path, label_type: str) -> set:
     phonemes = set() # type: set
     for fn in os.listdir(label_dir):
         if fn.endswith(label_type):
-            with open(join(label_dir, fn)) as f:
+            with open(os.path.join(label_dir, fn)) as f:
                 try:
                     line_phonemes = set(f.readline().split())
                 except UnicodeDecodeError:

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -34,12 +34,6 @@ def ensure_no_set_overlap(train, valid, test) -> None:
     train = set(train)
     valid = set(valid)
     test = set(test)
-    assert train - valid == train
-    assert train - test == train
-    assert valid - train == valid
-    assert valid - test == valid
-    assert test - train == test
-    assert test - valid == test
 
     if train & valid:
         logger.warning("train and valid have overlapping items: {}".format(train & valid))

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -11,7 +11,7 @@ import pickle
 from os.path import join
 import random
 import subprocess
-from typing import List, Callable, Tuple, Type, TypeVar
+from typing import List, Callable, Tuple, Type, TypeVar, Sequence
 
 import numpy as np
 
@@ -329,7 +329,7 @@ class Corpus:
             raise PersephoneException(
                 "The supplied path requires a 'label' subdirectory.")
 
-    def initialize_labels(self, labels):
+    def initialize_labels(self, labels: Sequence[str]) -> Tuple[dict, dict]:
         """Create mappings from label to index and index to label"""
         logger.debug("Creating mappings for labels")
 
@@ -340,7 +340,7 @@ class Corpus:
 
         return label_to_index, index_to_label
 
-    def prepare_feats(self):
+    def prepare_feats(self) -> None:
         """ Prepares input features"""
 
         logger.debug("Preparing input features")
@@ -366,7 +366,7 @@ class Corpus:
         if should_extract_feats:
             feat_extract.from_dir(self.feat_dir, self.feat_type)
 
-    def make_data_splits(self, max_samples):
+    def make_data_splits(self, max_samples) -> None:
         """ Splits the utterances into training, validation and test sets."""
 
         train_f_exists = self.train_prefix_fn.is_file()
@@ -436,7 +436,7 @@ class Corpus:
                 print(prefix, file=prefix_f)
 
     @staticmethod
-    def divide_prefixes(prefixes, seed=0):
+    def divide_prefixes(prefixes: List[str], seed:int=0) -> Tuple[List[str], List[str], List[str]]:
         """Divide data into training, validation and test subsets"""
         Ratios = namedtuple("Ratios", ["train", "valid", "test"])
         ratios=Ratios(.90, .05, .05)

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -578,16 +578,17 @@ class Corpus:
             return pickle.load(f)
 
 
-def determine_labels(tgt_dir, label_type):
+def determine_labels(target_dir: Path, label_type: str) -> set:
     """ Returns a set of phonemes found in the corpus. """
-    logger.info("Finding phonemes of type %s in directory %s", label_type, tgt_dir)
+    logger.info("Finding phonemes of type %s in directory %s", label_type, target_dir)
 
+    tgt_dir = str(target_dir)
     label_dir = os.path.join(tgt_dir, "label/")
     if not os.path.isdir(label_dir):
         raise FileNotFoundError(
             "The directory {} does not exist.".format(tgt_dir))
 
-    phonemes = set()
+    phonemes = set() # type: set
     for fn in os.listdir(label_dir):
         if fn.endswith(label_type):
             with open(join(label_dir, fn)) as f:

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -526,7 +526,11 @@ class ReadyCorpus(Corpus):
     utterances and segregated in a directory with a "wav" and "label" dir. """
 
     def __init__(self, tgt_dir, feat_type="fbank", label_type="phonemes"):
-
+        import warnings
+        warnings.warn(
+            "ReadyCorpus is deprecated, use Corpus instead",
+            DeprecationWarning
+        )
         labels = self.determine_labels(tgt_dir, label_type)
 
         super().__init__(feat_type, label_type, Path(tgt_dir), labels)

--- a/persephone/corpus.py
+++ b/persephone/corpus.py
@@ -50,11 +50,21 @@ def find_untranscribed_wavs(wav_path: Path, transcription_path: Path, label_type
     Args:
         wav_path: Path to search for wav files in
         transcription_path: Path to search for transcriptions in
-        label_type: The type of labels for transcriptions. Eg "phonemes" "ponemes_and_tones"
+        label_type: The type of labels for transcriptions. Eg "phonemes" "phonemes_and_tones"
     Returns:
         A list of all untranscribed prefixes
     """
-    raise NotImplementedError
+    audio_files = sorted(wav_path.glob("**/*.wav"))
+    transcription_files = sorted(transcription_path.glob("**/*.{}".format(label_type)))
+    
+    transcription_file_prefixes = [t_file.stem for t_file in transcription_files]
+
+    import pdb; pdb.set_trace()
+    untranscribed_prefixes = [] # type: List[str]
+    for a_file in audio_files:
+        if a_file.stem not in transcription_file_prefixes:
+            untranscribed_prefixes.append(a_file.stem)
+    return untranscribed_prefixes
 
 class Corpus:
     """ Represents a preprocessed corpus that is ready to be used in model

--- a/persephone/corpus_reader.py
+++ b/persephone/corpus_reader.py
@@ -81,7 +81,7 @@ class CorpusReader:
         random.seed(rand_seed)
 
         # Make a copy of the training prefixes, randomize their order, and take
-        # a subset. Doing random slection of a subset of training now ensures
+        # a subset. Doing random selection of a subset of training now ensures
         # the selection of of training sentences is invariant between calls to
         # train_batch_gen()
         self.train_fns = list(zip(*corpus.get_train_fns()))

--- a/persephone/tests/experiments/test_na.py
+++ b/persephone/tests/experiments/test_na.py
@@ -85,7 +85,7 @@ def test_tutorial():
     download_example_data(NA_EXAMPLE_LINK)
 
     # Test the first setup encouraged in the tutorial
-    labels = corpus.determine_labels(na_example_dir, "phonemes")
+    labels = corpus.determine_labels(Path(na_example_dir), "phonemes")
     corp = corpus.Corpus("fbank", "phonemes", Path(na_example_dir), labels)
 
     exp_dir = experiment.train_ready(corp, directory=EXP_BASE_DIR)
@@ -109,7 +109,7 @@ def test_fast():
 
     download_example_data(TINY_EXAMPLE_LINK)
 
-    labels = corpus.determine_labels(tiny_example_dir, "phonemes")
+    labels = corpus.determine_labels(Path(tiny_example_dir), "phonemes")
 
     corp = corpus.Corpus("fbank", "phonemes", Path(tiny_example_dir), labels)
     exp_dir = experiment.prep_exp_dir(directory=EXP_BASE_DIR)

--- a/persephone/tests/experiments/test_na.py
+++ b/persephone/tests/experiments/test_na.py
@@ -85,7 +85,9 @@ def test_tutorial():
     download_example_data(NA_EXAMPLE_LINK)
 
     # Test the first setup encouraged in the tutorial
-    corp = corpus.ReadyCorpus(na_example_dir)
+    labels = corpus.determine_labels(na_example_dir, "phonemes")
+    corp = corpus.Corpus("fbank", "phonemes", Path(na_example_dir), labels)
+
     exp_dir = experiment.train_ready(corp, directory=EXP_BASE_DIR)
 
     # Assert the convergence of the model at the end by reading the test scores

--- a/persephone/tests/experiments/test_na.py
+++ b/persephone/tests/experiments/test_na.py
@@ -107,8 +107,9 @@ def test_fast():
 
     download_example_data(TINY_EXAMPLE_LINK)
 
-    corp = corpus.ReadyCorpus(tiny_example_dir)
+    labels = corpus.determine_labels(tiny_example_dir, "phonemes")
 
+    corp = corpus.Corpus("fbank", "phonemes", Path(tiny_example_dir), labels)
     exp_dir = experiment.prep_exp_dir(directory=EXP_BASE_DIR)
     model = experiment.get_simple_model(exp_dir, corp)
     model.train(min_epochs=2, max_epochs=5)

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -1,0 +1,9 @@
+"""Tests for corpus related items"""
+import pytest
+def test_ready_corpus_deprecation():
+    from persephone.corpus import ReadyCorpus
+    with pytest.warns(DeprecationWarning):
+        try:
+            ReadyCorpus(tgt_dir="test_dir")
+        except FileNotFoundError:
+            pass

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -49,3 +49,23 @@ def test_determine_labels(fs): #fs is the fake filesystem fixture
 
     phoneme_and_tones_labels = determine_labels(base_dir, "phonemes_and_tones")
     assert phoneme_and_tones_labels
+
+
+def test_data_overlap():
+    """Tests that the overlap detection function works as advertised"""
+    train = set(["a", "b", "c"])
+    valid = set(["d", "e", "f"])
+    test = set(["g", "h", "i"])
+    from persephone.corpus import ensure_no_set_overlap
+    from persephone.exceptions import PersephoneException
+    ensure_no_set_overlap(train, valid, test)
+
+    overlap_with_train = set(["a"])
+    with pytest.raises(PersephoneException):
+        ensure_no_set_overlap(train, valid|overlap_with_train, test)
+    overlap_with_valid = set(["d"])
+    with pytest.raises(PersephoneException):
+        ensure_no_set_overlap(train, valid, test|overlap_with_valid)
+    overlap_with_test = set(["g"])
+    with pytest.raises(PersephoneException):
+        ensure_no_set_overlap(train|overlap_with_test, valid, test)

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -35,6 +35,24 @@ def test_missing_wav_dir(tmpdir):
             labels=["a", "b", "c"]
         )
 
+def test_create_corpus_no_data(tmpdir):
+    """Test that an attempt to create a Corpus object with no data raises an
+    exception warning us that there's no data"""
+    from persephone.corpus import Corpus
+    from pathlib import Path
+
+    wav_dir = tmpdir.mkdir("wav")
+    label_dir = tmpdir.mkdir("label")
+
+    from persephone.exceptions import PersephoneException
+
+    with pytest.raises(PersephoneException):
+        c = Corpus(
+                feat_type='fbank',
+                label_type='phonemes',
+                tgt_dir=Path(str(tmpdir)),
+                labels=["a", "b", "c"]
+            )
 
 
 def test_ready_corpus_deprecation():

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -3,6 +3,25 @@ import pytest
 
 #from pyfakefs.pytest_plugin import fs
 
+def test_corpus_import():
+    """Test we can import Corpus"""
+    from persephone.corpus import Corpus
+
+def test_missing_experiment_dir():
+    """A Corpus needs an experiment directory, check an exception is thrown
+    if the directory doesn't exist"""
+    from pathlib import Path
+    from persephone.corpus import Corpus
+
+    with pytest.raises(FileNotFoundError):
+        Corpus(
+            feat_type='fbank',
+            label_type='phonemes',
+            tgt_dir=Path("thisDoesNotExist"),
+            labels=["a", "b", "c"]
+        )
+
+
 def test_ready_corpus_deprecation():
     from persephone.corpus import ReadyCorpus
     with pytest.warns(DeprecationWarning):

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -7,3 +7,12 @@ def test_ready_corpus_deprecation():
             ReadyCorpus(tgt_dir="test_dir")
         except FileNotFoundError:
             pass
+
+
+def test_determine_labels_throws():
+    """Test that a non existant directory will throw"""
+    import pathlib
+    from persephone.corpus import determine_labels
+    non_existent_path = "thispathdoesntexist"
+    with pytest.raises(FileNotFoundError):
+        determine_labels(non_existent_path, "phonemes")

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -1,5 +1,8 @@
 """Tests for corpus related items"""
 import pytest
+
+from pyfakefs.pytest_plugin import fs
+
 def test_ready_corpus_deprecation():
     from persephone.corpus import ReadyCorpus
     with pytest.warns(DeprecationWarning):
@@ -16,3 +19,33 @@ def test_determine_labels_throws():
     non_existent_path = "thispathdoesntexist"
     with pytest.raises(FileNotFoundError):
         determine_labels(non_existent_path, "phonemes")
+
+@pytest.mark.skip("This currently fails because of a bug in pyfakefs,"
+                  "see https://github.com/jmcgeheeiv/pyfakefs/issues/409")
+def test_determine_labels(fs): #fs is the fake filesystem fixture
+    """test the function that determines what labels exist in a directory"""
+    from pyfakefs.fake_filesystem_unittest import Patcher
+
+    with Patcher(use_dynamic_patch=True) as patcher:
+        import pathlib
+    base_dir = pathlib.Path('/tmp/corpus_data')
+    label_dir = base_dir / "label"
+    fs.create_dir(str(base_dir))
+    fs.create_dir(str(label_dir))
+    test_1_phonemes = 'ɖ ɯ ɕ i k v̩'
+    test_1_phonemes_and_tones = 'ɖ ɯ ˧ ɕ i ˧ k v̩ ˧˥'
+    test_2_phonemes = 'g v̩ tsʰ i g v̩ k v̩'
+    test_2_phonemes_and_tones = 'g v̩ ˧ tsʰ i ˩ g v̩ ˩ k v̩ ˩'
+    fs.create_file(str(label_dir / "test1.phonemes"), contents=test_1_phonemes)
+    fs.create_file(str(label_dir / "test1.phonemes_and_tones"), contents=test_1_phonemes_and_tones)
+    fs.create_file(str(label_dir / "test2.phonemes"), contents=test_2_phonemes)
+    fs.create_file(str(label_dir / "test2.phonemes_and_tones"), contents=test_1_phonemes_and_tones)
+    assert base_dir.exists()
+    assert label_dir.exists()
+
+    from persephone.corpus import determine_labels
+    phoneme_labels = determine_labels(base_dir, "phonemes")
+    assert phoneme_labels
+
+    phoneme_and_tones_labels = determine_labels(base_dir, "phonemes_and_tones")
+    assert phoneme_and_tones_labels

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -85,9 +85,10 @@ def test_create_corpus_basic(tmpdir):
 
 def test_ready_corpus_deprecation():
     from persephone.corpus import ReadyCorpus
+    from pathlib import Path
     with pytest.warns(DeprecationWarning):
         try:
-            ReadyCorpus(tgt_dir="test_dir")
+            ReadyCorpus(tgt_dir=Path("test_dir"))
         except FileNotFoundError:
             pass
 

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -78,10 +78,10 @@ def test_untranscribed_wavs(tmpdir):
     wav_dir = tmpdir.mkdir("wav")
     label_dir = tmpdir.mkdir("label")
 
-    wav_untranscribed = wav_dir.join("untranscribed1.wav")
+    wav_untranscribed = wav_dir.join("untranscribed1.wav").write("")
 
-    wav_1 = wav_dir.join("1.wav")
-    transcription_1 = label_dir.join("1.phonemes")
+    wav_1 = wav_dir.join("1.wav").write("")
+    transcription_1 = label_dir.join("1.phonemes").write("")
 
     untranscribed_prefixes = find_untranscribed_wavs(Path(str(wav_dir)), Path(str(label_dir)), "phonemes")
     assert untranscribed_prefixes

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -1,7 +1,7 @@
 """Tests for corpus related items"""
 import pytest
 
-from pyfakefs.pytest_plugin import fs
+#from pyfakefs.pytest_plugin import fs
 
 def test_ready_corpus_deprecation():
     from persephone.corpus import ReadyCorpus
@@ -69,3 +69,20 @@ def test_data_overlap():
     overlap_with_test = set(["g"])
     with pytest.raises(PersephoneException):
         ensure_no_set_overlap(train|overlap_with_test, valid, test)
+
+def test_untranscribed_wavs(tmpdir):
+    """test that untranscribed wav files are found"""
+    from pathlib import Path
+    from persephone.corpus import find_untranscribed_wavs
+
+    wav_dir = tmpdir.mkdir("wav")
+    label_dir = tmpdir.mkdir("label")
+
+    wav_untranscribed = wav_dir.join("untranscribed1.wav")
+
+    wav_1 = wav_dir.join("1.wav")
+    transcription_1 = label_dir.join("1.phonemes")
+
+    untranscribed_prefixes = find_untranscribed_wavs(Path(str(wav_dir)), Path(str(label_dir)), "phonemes")
+    assert untranscribed_prefixes
+    assert "untranscribed1" in untranscribed_prefixes

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -21,6 +21,21 @@ def test_missing_experiment_dir():
             labels=["a", "b", "c"]
         )
 
+def test_missing_wav_dir(tmpdir):
+    """Test that a missing wav dir raises an error"""
+    from pathlib import Path
+    from persephone.corpus import Corpus
+    from persephone.exceptions import PersephoneException
+
+    with pytest.raises(PersephoneException):
+        Corpus(
+            feat_type='fbank',
+            label_type='phonemes',
+            tgt_dir=Path(str(tmpdir)),
+            labels=["a", "b", "c"]
+        )
+
+
 
 def test_ready_corpus_deprecation():
     from persephone.corpus import ReadyCorpus

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -96,7 +96,7 @@ def test_determine_labels_throws():
     """Test that a non existant directory will throw"""
     import pathlib
     from persephone.corpus import determine_labels
-    non_existent_path = "thispathdoesntexist"
+    non_existent_path = pathlib.Path("thispathdoesntexist")
     with pytest.raises(FileNotFoundError):
         determine_labels(non_existent_path, "phonemes")
 

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -85,4 +85,11 @@ def test_untranscribed_wavs(tmpdir):
 
     untranscribed_prefixes = find_untranscribed_wavs(Path(str(wav_dir)), Path(str(label_dir)), "phonemes")
     assert untranscribed_prefixes
+    assert len(untranscribed_prefixes) == 1
     assert "untranscribed1" in untranscribed_prefixes
+
+    untranscribed_prefixes_phonemes_and_tones = find_untranscribed_wavs(Path(str(wav_dir)), Path(str(label_dir)), "phonemes_and_tones")
+    assert untranscribed_prefixes_phonemes_and_tones
+    assert len(untranscribed_prefixes_phonemes_and_tones) == 2
+    assert "untranscribed1" in untranscribed_prefixes_phonemes_and_tones
+    assert "1" in untranscribed_prefixes_phonemes_and_tones

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -81,18 +81,6 @@ def test_create_corpus_basic(tmpdir):
     )
     assert c
 
-
-
-def test_ready_corpus_deprecation():
-    from persephone.corpus import ReadyCorpus
-    from pathlib import Path
-    with pytest.warns(DeprecationWarning):
-        try:
-            ReadyCorpus(tgt_dir=Path("test_dir"))
-        except FileNotFoundError:
-            pass
-
-
 def test_determine_labels_throws():
     """Test that a non existant directory will throw"""
     import pathlib

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -93,3 +93,20 @@ def test_untranscribed_wavs(tmpdir):
     assert len(untranscribed_prefixes_phonemes_and_tones) == 2
     assert "untranscribed1" in untranscribed_prefixes_phonemes_and_tones
     assert "1" in untranscribed_prefixes_phonemes_and_tones
+
+def test_untranscribed_prefixes_from_file(tmpdir):
+    """Test that extracting prefixes from an "untranscribed_prefixes.txt" file
+    will behave as advertised"""
+    from pathlib import Path
+    from persephone.corpus import get_untranscribed_prefixes_from_file
+    untranscribed_prefix_content = """foo
+bar
+baz"""
+    untranscribed_prefix_file = tmpdir.join("untranscribed_prefixes.txt").write(untranscribed_prefix_content)
+
+    untranscribed_prefixes = get_untranscribed_prefixes_from_file(Path(str(tmpdir)))
+    assert untranscribed_prefixes
+    assert len(untranscribed_prefixes) == 3
+    assert "foo" in untranscribed_prefixes
+    assert "bar" in untranscribed_prefixes
+    assert "baz" in untranscribed_prefixes

--- a/persephone/tests/test_corpus.py
+++ b/persephone/tests/test_corpus.py
@@ -54,6 +54,34 @@ def test_create_corpus_no_data(tmpdir):
                 labels=["a", "b", "c"]
             )
 
+@pytest.mark.skip("Need to make some wav data that ffmpeg can actually open "
+                  "then do something like base64 encode the data so we can make "
+                  "fixtures for wav data to supply for the test case")
+def test_create_corpus_basic(tmpdir):
+    """Test that an attempt to create a Corpus object with a minimal data set"""
+    from persephone.corpus import Corpus
+    from pathlib import Path
+
+    wav_dir = tmpdir.mkdir("wav")
+    label_dir = tmpdir.mkdir("label")
+
+    wav_test = wav_dir.join("test.wav").write("")
+    wav_train = wav_dir.join("train.wav").write("")
+    wav_valid = wav_dir.join("valid.wav").write("")
+
+    label_test = wav_dir.join("valid.phonemes").write("a")
+    label_train = wav_dir.join("valid.phonemes").write("b")
+    label_valid = wav_dir.join("valid.phonemes").write("c")
+
+    c = Corpus(
+        feat_type='fbank',
+        label_type='phonemes',
+        tgt_dir=Path(str(tmpdir)),
+        labels=["a", "b", "c"]
+    )
+    assert c
+
+
 
 def test_ready_corpus_deprecation():
     from persephone.corpus import ReadyCorpus

--- a/persephone/utils.py
+++ b/persephone/utils.py
@@ -153,7 +153,7 @@ def filter_by_size(feat_dir: Path, prefixes: List[str], feat_type: str,
                 if length <= max_samples]
     return prefixes
 
-def sort_by_size(feat_dir, prefixes, feat_type):
+def sort_by_size(feat_dir, prefixes, feat_type) -> List[str]:
     prefix_lens = get_prefix_lens(feat_dir, prefixes, feat_type)
     prefix_lens.sort(key=lambda prefix_len: prefix_len[1])
     prefixes = [prefix for prefix, _ in prefix_lens]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,6 @@
 tox
 pylint>1.8
 pytest
+pytest-cov
 mypy>=0.6
+pyfakefs

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,7 @@
 envlist=py35
 [testenv]
 deps=
-    pytest
-    pytest-cov
-    mypy
-    pylint
+	-r{toxinidir}/test_requirements.txt
 commands=
     pylint -E persephone
     mypy persephone


### PR DESCRIPTION
This PR aims to remove the `ReadyCorpus` class and implementing this via `Corpus` which closes #96. Will close #80 by implementing `untranscribed_wavs` functionality in `Corpus`

- [x] Implement untranscribed_wavs
- [x] Remove ReadyCorpus
- [x] Test Corpus creation
- [x] Improve `Corpus` test coverage

Also addresses #57, #158